### PR TITLE
Attempting to fix the preview of a journal image using the preview-api-dummy PR tag

### DIFF
--- a/manifests/previews/journal-api-dummy/preview-template.yaml
+++ b/manifests/previews/journal-api-dummy/preview-template.yaml
@@ -192,7 +192,7 @@ spec:
               prune: true
               targetNamespace: "journal--preview-{{ matrix.pr.number }}"
               images:
-              - name: elifesciences/journal
+              - name: ghcr.io/elifesciences/journal
                 newName: "{% raw %}{{ matrix.image.split(':')[0] }}{% endraw %}"
                 newTag: "{% raw %}{{ matrix.image.split(':')[1] }}{% endraw %}"
               postBuild:


### PR DESCRIPTION
If tagging a Journal PR with preview-api-dummy the image is not deployed to the preview env as expected in contrast, tagging with preview-prod-gateway deploys the image and leaves a comment with a link for the preview. 

The docker image name between these two options are different, with preview-api-dummy missing the ghcr.io/ prefix . Therefore I've added it in the hopes it can fix this issue. 