### PR TITLE
add scale-to-zero prod deployment for jats-ref-refinery

### DIFF
--- a/kustomizations/jats-ref-refinery/automations.yaml
+++ b/kustomizations/jats-ref-refinery/automations.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: jats-ref-refinery
+  namespace: journal
+spec:
+  interval: 5m
+  image: ghcr.io/elifesciences/jats-ref-refinery
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: jats-ref-refinery-stable
+  namespace: journal
+spec:
+  imageRepositoryRef:
+    name: jats-ref-refinery
+  filterTags:
+    pattern: '^main-[a-fA-F0-9]+-(?P<ts>\d{8}\.\d{4})$'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc

--- a/kustomizations/jats-ref-refinery/deployment.yaml
+++ b/kustomizations/jats-ref-refinery/deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jats-ref-refinery
+  namespace: journal
+spec:
+  template:
+    spec:
+      securityContext:
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+      containers:
+      - name: jats-ref-refinery
+        image: ghcr.io/elifesciences/jats-ref-refinery:latest
+        ports:
+        - containerPort: 8000
+        envFrom:
+        - secretRef:
+            name: ${secret_name}
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 0.5
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          periodSeconds: 2
+          failureThreshold: 5
+          timeoutSeconds: 2

--- a/kustomizations/jats-ref-refinery/http-scaled-object.yaml
+++ b/kustomizations/jats-ref-refinery/http-scaled-object.yaml
@@ -1,0 +1,23 @@
+---
+kind: HTTPScaledObject
+apiVersion: http.keda.sh/v1alpha1
+metadata:
+  name: jats-ref-refinery
+spec:
+  hosts:
+  - "${hostname}"
+  pathPrefixes:
+  - /
+  scaleTargetRef:
+    name: jats-ref-refinery
+    kind: Deployment
+    apiVersion: apps/v1
+    service: jats-ref-refinery-api
+    port: 8000
+  replicas:
+    min: 0
+    max: 10
+  scaledownPeriod: 300
+  scalingMetric:
+    concurrency:
+      targetValue: 2

--- a/kustomizations/jats-ref-refinery/ingress.yaml
+++ b/kustomizations/jats-ref-refinery/ingress.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jats-ref-refinery
+  namespace: journal
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: ${hostname}
+    http:
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: jats-ref-refinery-api-scaler
+              port:
+                number: ${keda_port:=8080}
+  tls:
+  - hosts:
+    - ${hostname}
+    secretName: ${hostname}-tls

--- a/kustomizations/jats-ref-refinery/kustomization.yaml
+++ b/kustomizations/jats-ref-refinery/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: journal
+
+resources:
+- automations.yaml
+- deployment.yaml
+- service.yaml
+- service-scaler.yaml
+- http-scaled-object.yaml
+- ingress.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/part-of: jats-ref-refinery
+    app.kubernetes.io/instance: jats-ref-refinery-${env}

--- a/kustomizations/jats-ref-refinery/service-scaler.yaml
+++ b/kustomizations/jats-ref-refinery/service-scaler.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jats-ref-refinery-api-scaler
+  namespace: journal
+  annotations:
+    traefik.ingress.kubernetes.io/service.nativelb: "true"
+spec:
+  type: ExternalName
+  externalName: ${keda_proxy:-'keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local'}
+  ports:
+    - port: 8080

--- a/kustomizations/jats-ref-refinery/service.yaml
+++ b/kustomizations/jats-ref-refinery/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jats-ref-refinery-api
+  namespace: journal
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    protocol: TCP

--- a/manifests/prod/jats-ref-refinery/app.yaml
+++ b/manifests/prod/jats-ref-refinery/app.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: jats-ref-refinery
+  namespace: journal--prod
+spec:
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: journal-team-deployment
+    namespace: flux-system
+  path: ./kustomizations/jats-ref-refinery
+  prune: true
+  targetNamespace: journal--prod
+  images:
+  - name: ghcr.io/elifesciences/jats-ref-refinery # {"$imagepolicy": "journal--prod:jats-ref-refinery-stable:name"}
+    newTag: main-57bd8136-20260415.1512 # {"$imagepolicy": "journal--prod:jats-ref-refinery-stable:tag"}
+  postBuild:
+    substitute:
+      env: prod
+      hostname: jats-ref-refinery.prod.elifesciences.org
+      secret_name: jats-ref-refinery-secret

--- a/manifests/prod/jats-ref-refinery/automation.yaml
+++ b/manifests/prod/jats-ref-refinery/automation.yaml
@@ -1,0 +1,35 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: jats-ref-refinery
+  namespace: journal--prod
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: journal-team-deployment
+    namespace: flux-system
+  update:
+    strategy: Setters
+    path: ./manifests/prod/jats-ref-refinery
+  git:
+    commit:
+      author:
+        name: Fluxbot
+        email: flux@elifesciences.org
+      messageTemplate: |
+        deploy({{ .AutomationObject }}): Automatic deploy
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $changes := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Namespace }}/{{ $resource.Name }}
+          Changes:
+        {{- range $_, $change := $changes }}
+          - {{ $change.Setter }}: {{ $change.OldValue }} -> {{ $change.NewValue }}
+        {{ end -}}
+        {{ end -}}

--- a/manifests/prod/jats-ref-refinery/secrets.yaml
+++ b/manifests/prod/jats-ref-refinery/secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jats-ref-refinery-secret
+  namespace: journal--prod
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: secret-store
+    kind: ClusterSecretStore
+  target:
+    name: jats-ref-refinery-secret
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: journal-team/jats-ref-refinery


### PR DESCRIPTION
- Matches the pattern(s) used for `jats-to-pdf`, with lower resources (as this is more lightweight)
- Secrets are wired up following the `basex-validator` convention, and assumes all key-value pairs from `journal-team/jats-ref-refinery` are defined in AWS and exposed